### PR TITLE
Fix a typo

### DIFF
--- a/lib/daimon_skycrawlers/url_consumer.rb
+++ b/lib/daimon_skycrawlers/url_consumer.rb
@@ -21,7 +21,7 @@ module DaimonSkycrawlers
       url = message[:url]
       depth = message[:depth]
 
-      # XXX When several crawlers are registed, how should they behave?
+      # XXX When several crawlers are registered, how should they behave?
       self.class.crawlers.each do |crawler|
         crawler.fetch(url, depth)
       end


### PR DESCRIPTION
`regist` does not exist actual English.
Use `register` instead.