### PR TITLE
Fix Gem::LoadError for generated application

### DIFF
--- a/lib/daimon_skycrawlers/generator/templates/new/Gemfile
+++ b/lib/daimon_skycrawlers/generator/templates/new/Gemfile
@@ -1,3 +1,4 @@
 source 'https://rubygems.org'
 
+gem 'rake'
 gem 'daimon_skycrawlers'


### PR DESCRIPTION
I found the following error:

```
% daimon-skycrawlers new sample
      create  sample/README.md
      create  sample/config/database.yml
      create  sample/Gemfile
      create  sample/Rakefile
      create  sample/crawler.rb
      create  sample/enqueue.rb
      create  sample/processor.rb
      create  sample/db/migrate/20160126113729_create_pages.rb
% cd sample/
% bundle install
Fetching gem metadata from https://rubygems.org/..
Fetching version metadata from https://rubygems.org/.
Resolving dependencies...
Using i18n 0.7.0
Using json 1.8.3
Using minitest 5.8.4
Using thread_safe 0.3.5
Using builder 3.2.2
Using arel 6.0.3
Using amq-protocol 2.0.1
Using multipart-post 2.0.0
Using mini_portile2 2.0.0
Using pg 0.18.4
Using thor 0.19.1
Using bundler 1.11.2
Using tzinfo 1.2.2
Using bunny 2.2.2
Using faraday 0.9.2
Using nokogiri 1.6.7.2
Using activesupport 4.2.5.1
Using faraday_middleware 0.10.0
Using activemodel 4.2.5.1
Using songkick_queue 0.6.0
Using activerecord 4.2.5.1
Using daimon_skycrawlers 0.1.0
Bundle complete! 1 Gemfile dependency, 22 gems now installed.
Use `bundle show [gemname]` to see where a bundled gem is installed.
% bundle exec rake -T
/home/myokoym/.rbenv/versions/2.3.0/lib/ruby/gems/2.3.0/gems/bundler-1.11.2/lib/bundler/rubygems_integration.rb:304:in `block in replace_gem': rake is not part of the bundle. Add it to Gemfile. (Gem::LoadError)
        from /home/myokoym/.rbenv/versions/2.3.0/bin/rake:22:in `<main>'
```