### PR TITLE
Generate migration files using MigrationGenerator

### DIFF
--- a/daimon_skycrawlers.gemspec
+++ b/daimon_skycrawlers.gemspec
@@ -24,6 +24,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency "faraday_middleware"
   spec.add_dependency "nokogiri"
   spec.add_dependency "activerecord"
+  spec.add_dependency "railties"
   spec.add_dependency "pg"
   spec.add_dependency "timers"
 

--- a/lib/daimon_skycrawlers/generator/new.rb
+++ b/lib/daimon_skycrawlers/generator/new.rb
@@ -1,4 +1,8 @@
 require "thor"
+require "rails/generators"
+require "rails/generators/actions"
+require "rails/generators/active_record"
+require "rails/generators/active_record/migration/migration_generator"
 
 module DaimonSkycrawlers
   module Generator
@@ -18,6 +22,16 @@ module DaimonSkycrawlers
         ].each do |path|
           template("#{path}.erb", "#{name}/#{path}")
         end
+        invoke(MigrationGenerator, [
+                 "CreatePage",
+                 "url:string",
+                 "headers:text",
+                 "body:binary",
+                 "last_modified_at:datetime",
+                 "etag:string",
+                 "timestamps"
+               ],
+          { destination_root: File.join(destination_root, name) })
       end
 
       def copy_files
@@ -31,12 +45,19 @@ module DaimonSkycrawlers
         ].each do |path|
           copy_file(path, "#{name}/#{path}")
         end
-        [
-          "db/migrate/create_pages.rb",
-        ].each do |path|
-          migration = "#{Time.now.strftime("%Y%m%d%H%M%S")}_#{File.basename(path)}"
-          copy_file(path, "#{name}/db/migrate/#{migration}")
-        end
+      end
+    end
+
+    class MigrationGenerator < ActiveRecord::Generators::MigrationGenerator
+      def self.source_root
+        ActiveRecord::Generators::MigrationGenerator.source_root
+      end
+
+      def create_migration_file
+        set_local_assigns!
+        validate_file_name!
+        dest = options[:destination_root]
+        migration_template @migration_template, "#{dest}/db/migrate/#{file_name}.rb"
       end
     end
   end


### PR DESCRIPTION
In previous version, we use ActiveRecord 4.x.
In this version, we use ActiveRecord 4.x or 5.x according to installed
ActiveRecord version.